### PR TITLE
feat(claims): add memberboard claim

### DIFF
--- a/modules/login/claim.js
+++ b/modules/login/claim.js
@@ -179,7 +179,8 @@
       claimTypes.ncarb = {
         personId: 'http://identity.ncarb.org/claims/personid',
         staffId: 'http://identity.ncarb.org/claims/staffId',
-        recordNumber: 'http://identity.ncarb.org/claims/recordNumber'
+        recordNumber: 'http://identity.ncarb.org/claims/recordNumber',
+        memberBoard: 'http://identity.ncarb.org/claims/memberBoard'
       };
 
       return claimTypes;


### PR DESCRIPTION
@davious @ESimmonds 

We would like to add a claim for the memberBoard. Currently we  are doing something like this:

`memberBoard: function (ClaimService) {
              return ClaimService.getClaim('boardMember') || 'LA';
            }`

We would like to just use the claim instead of the 'LA'.