### PR TITLE
fix(login): clear immediately, then timeout

### DIFF
--- a/modules/login/user.js
+++ b/modules/login/user.js
@@ -5,9 +5,9 @@
         .module('ncarb.services.login')
         .service('UserService', UserService);
 
-    UserService.$inject = ['StorageService', 'Endpoint', 'configuration', '$http', '$window', '$q', '$log'];
+    UserService.$inject = ['StorageService', 'Endpoint', 'configuration', '$http', '$window', '$q', '$log', '$timeout'];
 
-    function UserService(StorageService, Endpoint, configuration, $http, $window, $q, $log) {
+    function UserService(StorageService, Endpoint, configuration, $http, $window, $q, $log, $timeout) {
         var user;
         var policies = null;
         var service = {


### PR DESCRIPTION
The idea here is that on some slower systems, we need to extend the clear timeout for the localstorage to get cleared.