### PR TITLE
fix(login): isAuthenticated checks expiration

### DIFF
--- a/modules/login/user.js
+++ b/modules/login/user.js
@@ -37,7 +37,11 @@
         function isAuthenticated() {
             var token = StorageService.getItem('token');
 
-            return !!token;
+            return !!token && !expired(token);
+        };
+
+        function expired(token) {
+           return (token && token.expires_at && new Date(token.expires_at) < new Date());
         };
 
         function clear() {


### PR DESCRIPTION
the idea here is that isAuthenticated -- which login uses to check whether claims needs to be refreshed -- should also check that the token is not expired.